### PR TITLE
Move commands to their own files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: configure-test
+
+configure-test:
+	git remote add heroku-test https://git.heroku.com/commish-bot-test.git

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,19 @@
 .PHONY: install deploy configure-test deploy-test
+.DEFAULT_GOAL := help
 
-install:
+install: ## First time install
 	git remote add heroku https://git.heroku.com/nixon-groupme-test-bot.git
 	npm install
 
-deploy:
+deploy: ## Deploy to production
 	git push heroku
 
-configure-test:
+configure-test: ## Configure test remote
 	git remote add heroku-test https://git.heroku.com/commish-bot-test.git
 
-deploy-test:
+deploy-test: ## Deploy to staging
 	git push heroku-test
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,14 @@
-.PHONY: configure-test
+.PHONY: install deploy configure-test deploy-test
+
+install:
+	git remote add heroku https://git.heroku.com/nixon-groupme-test-bot.git
+	npm install
+
+deploy:
+	git push heroku
 
 configure-test:
 	git remote add heroku-test https://git.heroku.com/commish-bot-test.git
+
+deploy-test:
+	git push heroku-test

--- a/README.md
+++ b/README.md
@@ -1,7 +1,31 @@
-# CommishBot
+# Commish Bot
 
-This is a modified version of the callback bot used in the https://dev.groupme.com/tutorials tutorial at https://github.com/groupme/bot-tutorial-nodejs
+Malevolently Robotting For Life.
 
-It uses groupme's API https://dev.groupme.com/docs/v3
+### Installation
 
-Groupme Tagging: There is no documentation on tagging but if you look at a message with tags you see it's just an attachment of type tag
+```bash
+make install
+```
+
+### Deploying
+
+```bash
+make deploy
+```
+
+### Testing
+
+There's a test bot set up. You can run
+
+```bash
+make configure-test
+```
+
+to get the remote set up. Then, assuming you're a collaborator you can run
+
+```bash
+make deploy-test
+```
+
+to get your current changes up on the test bot.

--- a/bot.js
+++ b/bot.js
@@ -6,12 +6,9 @@ var cached = require('./cached');
 var pins = require('./pins');
 
 var botID = process.env.BOT_ID;
+var ffID = process.env.FF_ID;
 
-//create api key at
-// http://www.fantasyfootballnerd.com/fantasy-football-api
-var ffID = process.env.FF_ID; //env config var heroku FFN API key
-var FFNerd = require('fantasy-football-nerd');
-var ff = new FFNerd({ api_key: ffID});
+var ff = require('fantasy-football-nerd'){ api_key: ffId };
 
 /**
  * Extracts request message and responds if necessary.
@@ -36,7 +33,7 @@ function run(fullRequest) {
   if (command.match(pins.matcher) != null) {
     return pins.run(command);
   }
-  
+
   if (command.startsWith('!all')) {
     var messageToAll = '';
     if (command.length > 4 && command.startsWith('!all ')) {
@@ -106,9 +103,9 @@ function run(fullRequest) {
     var dieSides = '';
     if (command.length > 5 && command.startsWith('!roll ')) {
       dieSides = command.slice(5).replace(/\s/g, '');
-      if(isNaN(dieSides)){
+      if (isNaN(dieSides)) {
         var roll = 'roll is not a number';
-      }else{
+      } else{
         var roll = Math.floor((Math.random() * parseInt(dieSides)) + 1).toString();
       }
     }
@@ -119,25 +116,25 @@ function run(fullRequest) {
   } else if (command.startsWith('!bye')) {
         var byeWeek;
         var teams = "";
-        if(command.length > 4 && command.startsWith('!bye ')) {
+        if (command.length > 4 && command.startsWith('!bye ')) {
             byeWeek = command.slice(4).replace(/\s/g, '');
-            if(isNaN(byeWeek) || byeWeek < 4 || byeWeek > 13){
+            if (isNaN(byeWeek) || byeWeek < 4 || byeWeek > 13) {
               return new Promise(function(resolve, reject) {
                 resolve({
                   'bot_id' : botID,
                   'text' : 'Enter a valid bye week'
                 });
-              });          
-            } else{
+              });
+            } else {
                 var userByeWeek = parseInt(byeWeek);
                 var userPick = "Bye Week " + userByeWeek;
                 return new Promise(function(resolve, reject) {
                   ff.byes(function(byes) {
                       for (var key in byes) {
-                          if(key.toString() == userPick) {
+                          if (key.toString() == userPick) {
                             var obj = byes[key];
                             var teamKey = 'team';
-                            for(var temp in obj){
+                            for (var temp in obj) {
                               var teamStr = JSON.stringify(obj[temp]['team']).replace(/\"/g, "");
                               teams += teamStr + ' ';
                             }
@@ -146,11 +143,11 @@ function run(fullRequest) {
                       resolve({
                         'bot_id' : botID,
                         'text' : teams
-                      });       
+                      });
                   });
-                });                               
+                });
             }
-        }      
+        }
   } //new command starts here
 
   return Promise.resolve(response);
@@ -233,7 +230,7 @@ function sendHttpRequest(response, responder) {
   };
 
   var req = HTTPS.request(options, function(res) {
-    if(res.statusCode != 202) {
+    if (res.statusCode != 202) {
       console.log('rejecting bad status code ' + res.statusCode);
       console.log(res);
     }

--- a/bot.js
+++ b/bot.js
@@ -114,40 +114,40 @@ function run(fullRequest) {
       'text': roll
     }
   } else if (command.startsWith('!bye')) {
-        var byeWeek;
-        var teams = "";
-        if (command.length > 4 && command.startsWith('!bye ')) {
-            byeWeek = command.slice(4).replace(/\s/g, '');
-            if (isNaN(byeWeek) || byeWeek < 4 || byeWeek > 13) {
-              return new Promise(function(resolve, reject) {
-                resolve({
-                  'bot_id' : botID,
-                  'text' : 'Enter a valid bye week'
-                });
-              });
-            } else {
-                var userByeWeek = parseInt(byeWeek);
-                var userPick = "Bye Week " + userByeWeek;
-                return new Promise(function(resolve, reject) {
-                  ff.byes(function(byes) {
-                      for (var key in byes) {
-                          if (key.toString() == userPick) {
-                            var obj = byes[key];
-                            var teamKey = 'team';
-                            for (var temp in obj) {
-                              var teamStr = JSON.stringify(obj[temp]['team']).replace(/\"/g, "");
-                              teams += teamStr + ' ';
-                            }
-                          }
-                      }
-                      resolve({
-                        'bot_id' : botID,
-                        'text' : teams
-                      });
-                  });
-                });
+    var byeWeek;
+    var teams = "";
+    if (command.length > 4 && command.startsWith('!bye ')) {
+      byeWeek = command.slice(4).replace(/\s/g, '');
+      if (isNaN(byeWeek) || byeWeek < 4 || byeWeek > 13) {
+        return new Promise(function(resolve, reject) {
+          resolve({
+            'bot_id' : botID,
+            'text' : 'Enter a valid bye week'
+          });
+        });
+      } else {
+        var userByeWeek = parseInt(byeWeek);
+        var userPick = "Bye Week " + userByeWeek;
+        return new Promise(function(resolve, reject) {
+          ff.byes(function(byes) {
+            for (var key in byes) {
+              if (key.toString() == userPick) {
+                var obj = byes[key];
+                var teamKey = 'team';
+                for (var temp in obj) {
+                  var teamStr = JSON.stringify(obj[temp]['team']).replace(/\"/g, "");
+                  teams += teamStr + ' ';
+                }
+              }
             }
-        }
+            resolve({
+              'bot_id' : botID,
+              'text' : teams
+            });
+          });
+        });
+      }
+    }
   } //new command starts here
 
   return Promise.resolve(response);

--- a/bot.js
+++ b/bot.js
@@ -1,14 +1,20 @@
 var HTTPS = require('https');
-var insultGenerator = require('insultgenerator');
 var Promise = require('promise');
 
 var cached = require('./cached');
-var pins = require('./pins');
 
-var botID = process.env.BOT_ID;
-var ffID = process.env.FF_ID;
+var all = require('./commands/all');
+var bye = require('./commands/bye');
+var flip = require('./commands/flip');
+var insult = require('./commands/insult');
+var ping = require('./commands/ping');
+var pins = require('./commands/pins');
+var roll = require('./commands/roll');
 
-var ff = require('fantasy-football-nerd'){ api_key: ffId };
+var botId = process.env.BOT_ID;
+
+
+var commands = [all, bye, flip, insult, ping, pins, roll];
 
 /**
  * Extracts request message and responds if necessary.
@@ -27,180 +33,16 @@ function respond() {
  * @return {Promise<Object>} promise containing response object
  * @private
  */
-function run(fullRequest) {
-  var command = fullRequest.text;
+function run(request) {
+  var message = request.text;
   var response = null;
-  if (command.match(pins.matcher) != null) {
-    return pins.run(command);
+  for (var i = 0; i < commands.length; i++) {
+    command = commands[i];
+    if (message.match(command.matcher) != null) {
+      response = command.run(message, request);
+    }
   }
-
-  if (command.startsWith('!all')) {
-    var messageToAll = '';
-    if (command.length > 4 && command.startsWith('!all ')) {
-      messageToAll = command.slice(4);
-    }
-
-    userIds = [];
-    for (i = 0; i < cached.members.length; i++) {
-      member = cached.members[i];
-      userIds.push(member.userId);
-    }
-
-    response = {
-      'bot_id' : botID,
-      'text' : '@all' + messageToAll,
-      'attachments': [
-        {
-          'loci': Array(userIds.length).fill([0, 4]),
-          'type': 'mentions',
-          'user_ids': userIds
-        }
-      ]
-    };
-  } else if (command.startsWith('!fuckyou')) {
-    if (fullRequest.attachments !== undefined) {
-      var usersToInsult = [];
-      for (i = 0; i < fullRequest.attachments.length; i++) {
-        if (fullRequest.attachments[i].type === 'mentions') {
-          usersToInsult = fullRequest.attachments[i].user_ids;
-          break;
-        }
-      }
-      if (usersToInsult.length > 0) {
-        var attachments = createUserMentions(usersToInsult);
-        return new Promise(function(resolve, reject) {
-          insultGenerator(function(insult) {
-            resolve({
-              'bot_id' : botID,
-              'text' : attachments[1] + ' ' + insult,
-              'attachments': [attachments[0]]
-            });
-          });
-        });
-      }
-    }
-
-    return new Promise(function(resolve, reject) {
-      insultGenerator(function(insult) {
-        resolve({
-          'bot_id' : botID,
-          'text' : insult
-        });
-      });
-    });
-  } else if (command == '!ping') {
-    response = {
-      'bot_id': botID,
-      'text': 'pong'
-    }
-  } else if (command == '!flip') {
-    var flip = (Math.floor(Math.random() * 2) === 0) ? 'heads' : 'tails';
-    response = {
-      'bot_id': botID,
-      'text': flip
-    }
-  } else if (command.startsWith('!roll')) {
-    var dieSides = '';
-    if (command.length > 5 && command.startsWith('!roll ')) {
-      dieSides = command.slice(5).replace(/\s/g, '');
-      if (isNaN(dieSides)) {
-        var roll = 'roll is not a number';
-      } else{
-        var roll = Math.floor((Math.random() * parseInt(dieSides)) + 1).toString();
-      }
-    }
-    response = {
-      'bot_id': botID,
-      'text': roll
-    }
-  } else if (command.startsWith('!bye')) {
-    var byeWeek;
-    var teams = "";
-    if (command.length > 4 && command.startsWith('!bye ')) {
-      byeWeek = command.slice(4).replace(/\s/g, '');
-      if (isNaN(byeWeek) || byeWeek < 4 || byeWeek > 13) {
-        return new Promise(function(resolve, reject) {
-          resolve({
-            'bot_id' : botID,
-            'text' : 'Enter a valid bye week'
-          });
-        });
-      } else {
-        var userByeWeek = parseInt(byeWeek);
-        var userPick = "Bye Week " + userByeWeek;
-        return new Promise(function(resolve, reject) {
-          ff.byes(function(byes) {
-            for (var key in byes) {
-              if (key.toString() == userPick) {
-                var obj = byes[key];
-                var teamKey = 'team';
-                for (var temp in obj) {
-                  var teamStr = JSON.stringify(obj[temp]['team']).replace(/\"/g, "");
-                  teams += teamStr + ' ';
-                }
-              }
-            }
-            resolve({
-              'bot_id' : botID,
-              'text' : teams
-            });
-          });
-        });
-      }
-    }
-  } //new command starts here
-
   return Promise.resolve(response);
-}
-
-/**
- * Provides all necessary data to mention a group of users at
- * the beginning of a message.
- * @param usersToMention an array of user ids
- * @returns an Array with two elements:
- *    1. The "mentions" attachment object
- *    2. The text to prefix the message
- * @private
- */
-function createUserMentions(usersToMention) {
-  var membersMap = createMemberMap();
-  var mentionText = '';
-  var mentionAttachment = {
-      'loci': [],
-      'type': 'mentions',
-      'user_ids': []
-  };
-
-  var currentLoci = 0;
-  for (var i = 0; i < usersToMention.length; i++) {
-    var user = membersMap[usersToMention[i]];
-    if (user === undefined) {
-      // don't fail just because a user isn't recognised
-      console.log('User ' + usersToMention[i] + ' not recognised');
-      continue;
-    }
-
-    mentionText +=  '@' + user.nickname + ' ';
-    mentionAttachment.user_ids.push(usersToMention[i]);
-    mentionAttachment.loci.push(
-      [currentLoci, currentLoci + user.nickname.length + 1 /* length of @ sign */]);
-
-    currentLoci += user.nickname.length + 2 /* length of space + @ sign */;
-  }
-
-  return [mentionAttachment, mentionText.trim()];
-}
-
-/**
- * Creates a map of userIds to member objects
- * @private
- */
-function createMemberMap() {
-  var membersMap = {};
-  for (var member in cached.members) {
-    membersMap[cached.members[member].userId] = cached.members[member];
-  }
-  return membersMap;
 }
 
 /**
@@ -208,12 +50,12 @@ function createMemberMap() {
  * @private
  */
 function send(responsePromise, responder) {
+  console.log(responsePromise);
   responsePromise.then(function(response) {
     console.log('about to send message to groupme: ' + JSON.stringify(response));
     sendHttpRequest(response, responder);
   }, function(error) {
     response = {
-      'bot_id': botID,
       'text': 'There was an error processing the request: ' +
           JSON.stringify(error)
     }
@@ -222,6 +64,8 @@ function send(responsePromise, responder) {
 
 function sendHttpRequest(response, responder) {
   responder.res.writeHead(200);
+
+  response['bot_id'] = botId;
 
   var options = {
     hostname: 'api.groupme.com',
@@ -242,6 +86,7 @@ function sendHttpRequest(response, responder) {
   req.on('timeout', function(err) {
     console.log('timeout posting message '  + JSON.stringify(err));
   });
+
   req.end(JSON.stringify(response));
 
   responder.res.end();

--- a/commands/all.js
+++ b/commands/all.js
@@ -1,0 +1,30 @@
+var cached = require('../cached');
+
+var matcher = /!all(\s.*)/;
+
+function run(command, request) {
+  var messageToAll = '';
+  if (command.length > 4 && command.startsWith('!all ')) {
+    messageToAll = command.slice(4);
+  }
+
+  userIds = [];
+  for (i = 0; i < cached.members.length; i++) {
+    member = cached.members[i];
+    userIds.push(member.userId);
+  }
+
+  return {
+    'text' : '@all' + messageToAll,
+    'attachments': [
+      {
+        'loci': Array(userIds.length).fill([0, 4]),
+        'type': 'mentions',
+        'user_ids': userIds
+      }
+    ]
+  };
+}
+
+exports.run = run;
+exports.matcher = matcher;

--- a/commands/bye.js
+++ b/commands/bye.js
@@ -1,0 +1,44 @@
+var ffId = process.env.FF_ID;
+
+var FFNerd = require('fantasy-football-nerd');
+var ff = new FFNerd({ api_key: ffId });
+
+var matcher = /!bye(\s.*)/;
+
+function run(command, request) {
+  var byeWeek;
+  var teams = "";
+  if (command.length > 4 && command.startsWith('!bye ')) {
+    byeWeek = command.slice(4).replace(/\s/g, '');
+    if (isNaN(byeWeek) || byeWeek < 4 || byeWeek > 13) {
+      return new Promise(function(resolve, reject) {
+        resolve({
+          'text' : 'Enter a valid bye week'
+        });
+      });
+    } else {
+      var userByeWeek = parseInt(byeWeek);
+      var userPick = "Bye Week " + userByeWeek;
+      return new Promise(function(resolve, reject) {
+        ff.byes(function(byes) {
+          for (var key in byes) {
+            if (key.toString() == userPick) {
+              var obj = byes[key];
+              var teamKey = 'team';
+              for (var temp in obj) {
+                var teamStr = JSON.stringify(obj[temp]['team']).replace(/\"/g, "");
+                teams += teamStr + ' ';
+              }
+            }
+          }
+          resolve({
+            'text' : teams
+          });
+        });
+      });
+    }
+  }
+}
+
+exports.run = run;
+exports.matcher = matcher;

--- a/commands/flip.js
+++ b/commands/flip.js
@@ -1,0 +1,19 @@
+var matcher = /!roll(\s.*)/;
+
+function run(command, request) {
+  var dieSides = '';
+  if (command.length > 5 && command.startsWith('!roll ')) {
+    dieSides = command.slice(5).replace(/\s/g, '');
+    if (isNaN(dieSides)) {
+      var roll = 'roll is not a number';
+    } else{
+      var roll = Math.floor((Math.random() * parseInt(dieSides)) + 1).toString();
+    }
+  }
+  return {
+    'text': roll
+  }
+}
+
+exports.run = run;
+exports.matcher = matcher;

--- a/commands/insult.js
+++ b/commands/insult.js
@@ -1,0 +1,92 @@
+var Promise = require('promise');
+var insultGenerator = require('insultgenerator');
+
+var cached = require('../cached');
+
+var matcher = /!fuckyou(s|\s.*)/;
+
+function run(command, request) {
+  if (request.attachments !== undefined) {
+    var usersToInsult = [];
+    for (i = 0; i < request.attachments.length; i++) {
+      if (request.attachments[i].type === 'mentions') {
+        usersToInsult = request.attachments[i].user_ids;
+        break;
+      }
+    }
+    if (usersToInsult.length > 0) {
+      var attachments = createUserMentions(usersToInsult);
+      return new Promise(function(resolve, reject) {
+        insultGenerator(function(insult) {
+          resolve({
+            'text' : attachments[1] + ' ' + insult,
+            'attachments': [attachments[0]]
+          });
+        });
+      });
+    }
+  }
+
+  return new Promise(function(resolve, reject) {
+    insultGenerator(function(insult) {
+      resolve({
+        'text' : insult
+      });
+    });
+  });
+}
+
+/**
+ * Creates a map of userIds to member objects
+ * @private
+ */
+function createMemberMap() {
+  var membersMap = {};
+  for (var member in cached.members) {
+    membersMap[cached.members[member].userId] = cached.members[member];
+  }
+  return membersMap;
+}
+
+
+/**
+ * Provides all necessary data to mention a group of users at
+ * the beginning of a message.
+ * @param usersToMention an array of user ids
+ * @returns an Array with two elements:
+ *    1. The "mentions" attachment object
+ *    2. The text to prefix the message
+ * @private
+ */
+function createUserMentions(usersToMention) {
+  var membersMap = createMemberMap();
+  var mentionText = '';
+  var mentionAttachment = {
+      'loci': [],
+      'type': 'mentions',
+      'user_ids': []
+  };
+
+  var currentLoci = 0;
+  for (var i = 0; i < usersToMention.length; i++) {
+    var user = membersMap[usersToMention[i]];
+    if (user === undefined) {
+      // don't fail just because a user isn't recognised
+      console.log('User ' + usersToMention[i] + ' not recognised');
+      continue;
+    }
+
+    mentionText +=  '@' + user.nickname + ' ';
+    mentionAttachment.user_ids.push(usersToMention[i]);
+    mentionAttachment.loci.push(
+      [currentLoci, currentLoci + user.nickname.length + 1 /* length of @ sign */]);
+
+    currentLoci += user.nickname.length + 2 /* length of space + @ sign */;
+  }
+
+  return [mentionAttachment, mentionText.trim()];
+}
+
+
+exports.run = run;
+exports.matcher = matcher;

--- a/commands/ping.js
+++ b/commands/ping.js
@@ -1,0 +1,10 @@
+var matcher = /!ping/;
+
+function run(command, request) {
+  return {
+    'text': 'pong'
+  };
+}
+
+exports.run = run;
+exports.matcher = matcher;

--- a/commands/pins.js
+++ b/commands/pins.js
@@ -1,7 +1,6 @@
 var pg = require('pg');
 var Promise = require('promise');
 
-var botID = process.env.BOT_ID;
 var dbUrl = process.env.DATABASE_URL;
 var matcher = /!pin(s|\s.*)/;
 
@@ -9,7 +8,7 @@ var matcher = /!pin(s|\s.*)/;
  * Processes a !pin command and produces a JSON object response
  * @returns {Promise<Object>} a promise of the response object.
  */
-function run(command) {
+function run(command, request) {
   pg.defaults.ssl = true;
 
   var splitCommand = command.split(' ');
@@ -140,7 +139,7 @@ function createPin(pinName, pinContent) {
       selectQuery.on('error', function(error) {
         resolve(produceResponseObjectForText('Error creating pin, go hassle Mike. ' + err));
       })
-      
+
     } catch (e) {
       reject(e);
     }
@@ -152,7 +151,7 @@ function createPin(pinName, pinContent) {
  * Produce an immediate response with some text.
  */
 function produceImmediateResponse(response) {
-  return Promise.resolve(produceResponseObjectForText(response));
+  return produceResponseObjectForText(response);
 }
 
 
@@ -161,9 +160,8 @@ function produceImmediateResponse(response) {
  */
  function produceResponseObjectForText(text) {
   return {
-      'bot_id' : botID,
       'text' : text
-  };  
+  };
  }
 
 exports.run = run;

--- a/commands/roll.js
+++ b/commands/roll.js
@@ -1,0 +1,11 @@
+var matcher = /!flip/;
+
+function run(command, request) {
+  var flip = (Math.floor(Math.random() * 2) === 0) ? 'heads' : 'tails';
+  return {
+    'text': flip
+  }
+}
+
+exports.run = run;
+exports.matcher = matcher;

--- a/heroku-test
+++ b/heroku-test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+heroku $@ --remote "heroku-test"


### PR DESCRIPTION
- Puts commands in `commands/{command}.js`.
- Each command exposes two properties.
  - `matcher` to be run with `message.match({command}.matcher)` and decide if the command should be run or not.
  - `run(command, request)` to actually run the command.
- `bot_id` is now attached to the response right before sending it off.
- All responses are now `Promise.resolve`'d regardless of if they're a `Promise` or not. This [appears to be the way to handle this](http://stackoverflow.com/a/27746324).
