### PR TITLE
Fix the usage docs

### DIFF
--- a/commands/pins.js
+++ b/commands/pins.js
@@ -24,9 +24,9 @@ var matcher = /!pin(s|\s.*)/;
     var content = splitCommand.slice(3).join(' ');
     return createPin(splitCommand[2], content);
   }
-  if (splitCommand.length >= 3 && splitCommand[1] === "remove") {
-    // Command to remove a pin
-    return removePin(splitCommand[2].toLowerCase());
+  if (splitCommand.length >= 3 && splitCommand[1] === "delete") {
+    // Command to delete a pin
+    return deletePin(splitCommand[2].toLowerCase());
   }
 
   // Some parsing error occured.
@@ -107,9 +107,9 @@ function showPin(pinName) {
 
 
 /**
- * Remove a pin with a given name, otherwise give an appropriate error response.
+ * Delete a pin with a given name, otherwise give an appropriate error response.
  */
- function removePin(pinName) {
+ function deletePin(pinName) {
   return new Promise(function(resolve, reject) {
     try {
       var client = new pg.Client(dbUrl);

--- a/commands/pins.js
+++ b/commands/pins.js
@@ -18,21 +18,23 @@ var matcher = /!pin(s|\s.*)/;
   if (splitCommand.length === 2) {
     // Command to show a pin's value
     return showPin(splitCommand[1].toLowerCase());
-  } 
+  }
   if (splitCommand.length >= 3 && splitCommand[1] === "create") {
     // Command to create a pin
     var content = splitCommand.slice(3).join(' ');
     return createPin(splitCommand[2], content);
-  } 
+  }
   if (splitCommand.length >= 3 && splitCommand[1] === "remove") {
     // Command to remove a pin
     return removePin(splitCommand[2].toLowerCase());
   }
 
   // Some parsing error occured.
-  return produceImmediateResponse('Correct Usage:\n' +
-      '!pins (list pins)\n!pin {name} (view pin)\n' +
-      '!pin {name} {content} (create pin)');
+  return produceImmediateResponse('Usage:\n' +
+      '!pins  # list pins\n'
+      '!pin {name}  # view pin\n' +
+      '!pin create {name} {content}  # create pin'\n' +
+      '!pin delete {name} {content}  # delete pin');
 }
 
 


### PR DESCRIPTION
Something I really struggle with is how to get the non-coders to recognize "you should type this" from "this is what this does".

I did like Python-comment-style `#`'s in this commit, but I'm pretty confident that would be confusing. Idk, open to suggestions.

Also, change `remove` to `delete`.